### PR TITLE
Exclude 'micro-ecc-src' target from 'all'

### DIFF
--- a/cmake/nrf5_external_libs.cmake
+++ b/cmake/nrf5_external_libs.cmake
@@ -133,6 +133,7 @@ else()
   # Download uECC from github.
   include(ExternalProject)
   ExternalProject_Add(micro_ecc_src
+    EXCLUDE_FROM_ALL TRUE
     PREFIX external/micro_ecc_src
     GIT_REPOSITORY "https://github.com/kmackay/micro-ecc.git"
     BUILD_COMMAND ""


### PR DESCRIPTION
Building 'all' target previously resulted in fetching and building the Micro ECC library from GitHub even it it wasn't used at all.