### PR TITLE
CMake cache variables for stack size and heap size

### DIFF
--- a/cmake/nrf5.cmake
+++ b/cmake/nrf5.cmake
@@ -140,6 +140,16 @@ if(NRF5_STACK_SIZE)
   message(STATUS "Using stack size: ${NRF5_STACK_SIZE}")
 endif()
 
+# Heap size
+set(NRF5_HEAP_SIZE "" CACHE STRING "Max. size of the heap (in bytes), defines `__HEAP_SIZE` accordingly. If not specified, a default value for the specified target will be used.")
+if(NRF5_HEAP_SIZE)
+  if(NOT NRF5_HEAP_SIZE MATCHES "^[1-9][0-9]*$")
+    message(FATAL_ERROR "NRF5_HEAP_SIZE must be a positive decimal integer")
+  endif()
+  add_compile_options("-D__HEAP_SIZE=${NRF5_HEAP_SIZE}")
+  message(STATUS "Using heap size: ${NRF5_HEAP_SIZE}")
+endif()
+
 # NRFJPROG executable
 set(NRF5_NRFJPROG "" CACHE FILEPATH "nrfjprog utility executable file. If not specified, it is assumed that nrfjprog is available from PATH.")
 if(NOT NRF5_NRFJPROG)

--- a/cmake/nrf5.cmake
+++ b/cmake/nrf5.cmake
@@ -130,6 +130,9 @@ if(NRF5_APPCONFIG_PATH)
   message(STATUS "Using app_config.h include path: ${NRF5_APPCONFIG_PATH}")
 endif()
 
+# NOTE: if `__STACK_SIZE` and/or `__HEAP_SIZE` are not the defined, the startup (.S) file automatically defines stack/heap boundaries
+# using default values for the specified target
+
 # Stack size
 set(NRF5_STACK_SIZE "" CACHE STRING "Max. size of the stack (in bytes), defines `__STACK_SIZE` accordingly. If not specified, a default value for the specified target will be used.")
 if(NRF5_STACK_SIZE)

--- a/cmake/nrf5.cmake
+++ b/cmake/nrf5.cmake
@@ -130,6 +130,16 @@ if(NRF5_APPCONFIG_PATH)
   message(STATUS "Using app_config.h include path: ${NRF5_APPCONFIG_PATH}")
 endif()
 
+# Stack size
+set(NRF5_STACK_SIZE "" CACHE STRING "Max. size of the stack (in bytes), defines `__STACK_SIZE` accordingly. If not specified, a default value for the specified target will be used.")
+if(NRF5_STACK_SIZE)
+  if(NOT NRF5_STACK_SIZE MATCHES "^[1-9][0-9]*$")
+    message(FATAL_ERROR "NRF5_STACK_SIZE must be a positive decimal integer")
+  endif()
+  add_compile_options("-D__STACK_SIZE=${NRF5_STACK_SIZE}")
+  message(STATUS "Using stack size: ${NRF5_STACK_SIZE}")
+endif()
+
 # NRFJPROG executable
 set(NRF5_NRFJPROG "" CACHE FILEPATH "nrfjprog utility executable file. If not specified, it is assumed that nrfjprog is available from PATH.")
 if(NOT NRF5_NRFJPROG)


### PR DESCRIPTION
This adds support for `NRF5_STACK_SIZE` and `NRF5_HEAP_SIZE` CMake cache variables which will add `__STACK_SIZE` and `__HEAP_SIZE` compile options accordingly.

Those are not mandatory. If `__STACK_SIZE` or `__HEAP_SIZE` are not defined, the startup file (.S) will take care of setting up default stack/heap boundaries for the specified target.