### PR TITLE
Support for 'blank' and 'mbr' configurations

### DIFF
--- a/ci/scripts/build_all_examples.sh
+++ b/ci/scripts/build_all_examples.sh
@@ -42,6 +42,7 @@ function build_all_configs() {
         # Identify SoftDevice variants (including 'blank' configs) available for the specified board
         supported_sd_variant_dirs=($(ls -d $board_dir/s* 2> /dev/null))
         supported_sd_variant_dirs+=($(ls -d $board_dir/blank 2> /dev/null))
+        supported_sd_variant_dirs+=($(ls -d $board_dir/mbr 2> /dev/null))
 
         if [[ "${#supported_sd_variant_dirs[@]}" -eq 0 ]]; then
             echo "No configurations found for the '$example' for the '$board' board (config. dir.: $config_dir). Build skipped."

--- a/ci/scripts/build_all_examples.sh
+++ b/ci/scripts/build_all_examples.sh
@@ -39,11 +39,12 @@ function build_all_configs() {
             continue
         fi
 
-        # Identify SoftDevice variants available for the specified board (SoftDevice configurations only)
+        # Identify SoftDevice variants (including 'blank' configs) available for the specified board
         supported_sd_variant_dirs=($(ls -d $board_dir/s* 2> /dev/null))
+        supported_sd_variant_dirs+=($(ls -d $board_dir/blank 2> /dev/null))
 
-        if [[ ${#supported_sd_variant_dirs[@]} -eq 0 ]]; then
-            echo "A SoftDevice configuration for the '$example' for the '$board' board is not available (config. dir.: $config_dir). Build skipped."
+        if [[ "${#supported_sd_variant_dirs[@]}" -eq 0 ]]; then
+            echo "No configurations found for the '$example' for the '$board' board (config. dir.: $config_dir). Build skipped."
             continue
         fi
 

--- a/cmake/nrf5.cmake
+++ b/cmake/nrf5.cmake
@@ -182,7 +182,7 @@ target_include_directories(nrf5_mdk PUBLIC
   "${NRF5_SDK_PATH}/modules/nrfx/mdk"
 )
 
-if(${NRF5_SOFTDEVICE_VARIANT} STREQUAL "blank")
+if(${NRF5_SOFTDEVICE_VARIANT} MATCHES "^(blank|mbr)$")
   # SoC no SoftDevice variant.
   add_library(nrf5_soc OBJECT
     "${NRF5_SDK_PATH}/components/drivers_nrf/nrf_soc_nosd/nrf_nvic.c"

--- a/cmake/nrf5_validate.cmake
+++ b/cmake/nrf5_validate.cmake
@@ -225,8 +225,8 @@ function(nrf5_get_startup_file sdk_path target out_startup_file out_system_file)
 endfunction()
 
 function(nrf5_validate_softdevice_variant sdk_path sdk_version target sd_variant out_sd_hex_file_path out_sd_flags)
-  # If we have blank sd_variant then continue...
-  if(sd_variant STREQUAL blank)
+  # If we have blank or mbr sd_variant then continue...
+  if(sd_variant MATCHES "^(blank|mbr)$")
     return()
   endif()
 


### PR DESCRIPTION
'blank' and 'mbr' configurations can now be build manually or by using 'build_example.sh'/'build_all_examples.sh' scripts